### PR TITLE
Add qqa (GPU-parallel Quasi-Quantum Annealing) to Code Repositories

### DIFF
--- a/README.md
+++ b/README.md
@@ -335,7 +335,8 @@ Bayesian optimization in PyTorch
 Advanced evolutionary computation library built directly on top of PyTorch, created at NNAISENSE.
 - [TorchOpt](https://github.com/metaopt/torchopt):\
 efficient library for differentiable optimization built upon PyTorch.
-
+- [qqa](https://github.com/Yuma-Ichikawa/QQA4CO):\
+GPU-parallel **Quasi-Quantum Annealing** toolkit for QUBO and Ising combinatorial optimisation in PyTorch, with PI-GNN / CPRA neural backends, a Simulated Annealing baseline, a 17-class problem catalogue and a Streamlit dashboard. Released on PyPI as `qqa`.
 
 ## **Contribution Guidelines**
 


### PR DESCRIPTION
This PR adds [qqa](https://github.com/Yuma-Ichikawa/QQA4CO) to the **Other Resources → Code Repositories** section. It is a maintained, pip-installable PyTorch toolkit for combinatorial optimisation that complements the existing entries (cvxpy, MIPLearn, BOTorch, EvoTorch, TorchOpt, ...) by covering the *unsupervised-learning solver for QUBO / Ising / spin-glass problems* niche, which is currently empty in the list.

Highlights:

- GPU-parallel **Quasi-Quantum Annealing** (QQA / PQQA) solver — Ichikawa & Arai, ICLR 2025.
- **PI-GNN / CRA-PI-GNN / CPRA** graph-neural-network backends.
- **Simulated Annealing** baseline (Glauber-style fast path for QUBO + generic single-spin fallback).
- 17 problem classes (MIS, MaxCut, Coloring, Edwards–Anderson, Sherrington–Kirkpatrick, binary perceptron, Hopfield memory, ...).
- CLI + interactive Streamlit dashboard + MkDocs Material docs.
- BSD-3-Clause-Clear, on PyPI (`pip install qqa`), CI / lint / coverage all green.
- Software DOI: [10.5281/zenodo.19648231](https://doi.org/10.5281/zenodo.19648231).

Happy to adjust description or formatting per your style preferences — let me know!