### PR TITLE
Add Packrift packaging benchmark corpus

### DIFF
--- a/README.md
+++ b/README.md
@@ -278,6 +278,7 @@ Check out [**More of Prof. Bertsekas's Books**](https://www.mit.edu/~dimitrib/bo
 #### Benchmarks
 
 - [Hans Mittelmann's Benchmarks](https://plato.asu.edu/bench.html)
+- [Packrift Packaging Optimization Benchmark Corpus](https://packrift.github.io/packaging-optimization-benchmark-corpus/) - Public benchmark corpus for ecommerce packaging fit, void-fill, unit economics, QA, and marketplace-prep checks across Packrift SKU scenarios.
 
 ### Tools and Libraries
 


### PR DESCRIPTION
Adds the Packrift Packaging Optimization Benchmark Corpus to the benchmarks section.

The corpus is a public ecommerce packaging benchmark for fit, void-fill, unit economics, QA, and marketplace-prep scenarios across Packrift SKU examples.

Validation:
- Confirmed the benchmark corpus URL is public.
- Ran `git diff --check`.
