### PR TITLE
Add or-tools-wasm

### DIFF
--- a/README.md
+++ b/README.md
@@ -282,6 +282,7 @@ Check out [**More of Prof. Bertsekas's Books**](https://www.mit.edu/~dimitrib/bo
 ### Tools and Libraries
 
 - [**Google OR-Tools**](https://developers.google.com/optimization/) | [examples](https://developers.google.com/optimization/examples) | [repository](https://github.com/google/or-tools)
+- [**or-tools-wasm**](https://github.com/Axelwickm/or-tools-wasm) - Multithreaded Typescript/Wasm build of Google OR-Tools.
 - [**COIN-OR**](https://www.coin-or.org/) | [repository](https://github.com/coin-or/)
 - [**MiniZinc**](https://www.minizinc.org/) - Constraint modeling language.
 - [**GAMS**](https://www.gams.com/) - High-level modeling system.


### PR DESCRIPTION
Adds or-tools-wasm to Tools and Libraries as a multithreaded Wasm build of Google OR-Tools.